### PR TITLE
Added WaitReady to chromedp run command

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -29,6 +29,7 @@ func (c *Crawler) GetScreenshot() (error, []byte) {
 	if err := chromedp.Run(ctx,
 		chromedp.Emulate(c.generateDevice()),
 		chromedp.Navigate(c.URL),
+		chromedp.WaitReady("body"),
 		chromedp.CaptureScreenshot(&buf),
 	); err != nil {
 		log.Println(err)


### PR DESCRIPTION
Updated screenshot after adding `WaitReady` method to chromedp run script:
![test](https://user-images.githubusercontent.com/31708774/212490710-64b830b1-9c11-46da-9b9d-ea8a5b832a80.png)
